### PR TITLE
Use clientpath exclusion

### DIFF
--- a/screen_import.py
+++ b/screen_import.py
@@ -28,7 +28,7 @@ command = [
 ]
 
 if not ns.force:
-    command += ["--exclude=filename"]
+    command += ["--exclude=clientpath"]
 
 if ns.screen[-1] == "/":
     ns.screen = ns.screen[0:-1]


### PR DESCRIPTION
With https://github.com/joshmoore/openmicroscopy/commit/a7784586459682bbb747050e1fdf50b2ed910d9e
it's now possible to exclude based on the entirety of the client path
rather than just the filename. This should prevent a number of different
problems we've had.