### PR TITLE
Simple check for JAVA_OPTS

### DIFF
--- a/screen_import.py
+++ b/screen_import.py
@@ -2,6 +2,7 @@
 
 from argparse import ArgumentParser
 from glob import glob
+from os import environ
 from os.path import basename
 from os.path import dirname
 from os.path import expanduser
@@ -9,6 +10,8 @@ from os.path import exists
 from os.path import join
 from subprocess import call
 
+if "JAVA_OPTS" not in environ:
+   raise Exception("Set memory?")
 
 bin = expanduser("~/OMERO.server/bin/omero")
 assert exists(bin)


### PR DESCRIPTION
Not having JAVA_OPTS set to something like -Xmx8G is
almost *never* what you want to happen. Now we actively
check beforehand.

cc: @sbesson @manics @eleanorwilliams 