### PR TITLE
Add file pattern support

### DIFF
--- a/pyidr/file_pattern.py
+++ b/pyidr/file_pattern.py
@@ -1,0 +1,75 @@
+"""
+Bio-Formats style file patterns.
+
+www.openmicroscopy.org/site/support/bio-formats5.1/formats/pattern-file.html
+"""
+
+import re
+import string
+
+
+class InvertedRangeError(Exception):
+    pass
+
+
+def _expand_letter_range(start, stop, step):
+    if not(start.isalpha() and stop.isalpha()):
+        raise ValueError("non-literal range: %s-%s" % (start, stop))
+    if (start.isupper() != stop.isupper()):
+        raise ValueError("mixed case range: %s-%s" % (start, stop))
+    letters = string.uppercase if start.isupper() else string.lowercase
+    start = letters.index(start)
+    stop = letters.index(stop) + 1
+    if stop <= start:
+        raise InvertedRangeError
+    return [letters[_] for _ in xrange(start, stop, step)]
+
+
+def expand_range(r):
+    try:
+        r, step = r.strip().split(":")
+    except ValueError:
+        step = 1
+    else:
+        try:
+            step = int(step)
+        except ValueError:
+            raise ValueError("non-numeric step: %r" % (step,))
+    r = r.strip()
+    try:
+        start, stop = r.split("-")
+    except ValueError:
+        return [r]
+    try:
+        start = int(start)
+    except ValueError:
+        try:
+            return _expand_letter_range(start, stop, step)
+        except InvertedRangeError:
+            raise ValueError("inverted range: %s" % r)
+    else:
+        stop = int(stop) + 1
+        if stop <= start:
+            raise ValueError("inverted range: %s" % r)
+        step = int(step)
+        # TODO: support leading zeros
+        return map(str, range(start, stop, step))
+
+
+def expand_block(block):
+    return sum((expand_range(_.strip()) for _ in block.split(",")), [])
+
+
+class FilePattern(object):
+
+    BLOCK_START = "<"
+    BLOCK_END = ">"
+    BLOCK = re.compile(r"<(.+?)>")
+
+    def __init__(self, pattern):
+        self.pattern = pattern
+
+    def blocks(self):
+        return re.findall(self.BLOCK, self.pattern)
+
+    # TODO: add iterator through expanded filenames

--- a/pyidr/file_pattern.py
+++ b/pyidr/file_pattern.py
@@ -6,6 +6,7 @@ www.openmicroscopy.org/site/support/bio-formats5.1/formats/pattern-file.html
 
 import re
 import string
+from itertools import product, izip_longest
 
 
 class InvertedRangeError(Exception):
@@ -73,4 +74,7 @@ class FilePattern(object):
     def blocks(self):
         return re.findall(r"<(.+?)>", self.pattern)
 
-    # TODO: add iterator through expanded filenames
+    def filenames(self):
+        fixed = re.split(r"<.+?>", self.pattern)
+        for repl in product(*(expand_block(_) for _ in self.blocks())):
+            yield "".join(sum(izip_longest(fixed, repl, fillvalue=""), ()))

--- a/pyidr/file_pattern.py
+++ b/pyidr/file_pattern.py
@@ -67,14 +67,10 @@ def expand_block(block):
 
 class FilePattern(object):
 
-    BLOCK_START = "<"
-    BLOCK_END = ">"
-    BLOCK = re.compile(r"<(.+?)>")
-
     def __init__(self, pattern):
         self.pattern = pattern
 
     def blocks(self):
-        return re.findall(self.BLOCK, self.pattern)
+        return re.findall(r"<(.+?)>", self.pattern)
 
     # TODO: add iterator through expanded filenames

--- a/pyidr/file_pattern.py
+++ b/pyidr/file_pattern.py
@@ -41,6 +41,7 @@ def expand_range(r):
     except ValueError:
         return [r]
     try:
+        start_str = start
         start = int(start)
     except ValueError:
         try:
@@ -48,12 +49,16 @@ def expand_range(r):
         except InvertedRangeError:
             raise ValueError("inverted range: %s" % r)
     else:
+        stop_str = stop
         stop = int(stop) + 1
         if stop <= start:
             raise ValueError("inverted range: %s" % r)
         step = int(step)
-        # TODO: support leading zeros
-        return map(str, range(start, stop, step))
+        if len(start_str) != len(stop_str):
+            return map(str, range(start, stop, step))
+        else:
+            fmt = "%%0%dd" % len(start_str)
+            return [fmt % _ for _ in xrange(start, stop, step)]
 
 
 def expand_block(block):

--- a/scripts/check_screen.py
+++ b/scripts/check_screen.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import sys
+import os
+from ConfigParser import ConfigParser
+from argparse import ArgumentParser
+
+from pyidr.file_pattern import FilePattern
+
+
+def parse_cl(argv):
+    parser = ArgumentParser()
+    parser.add_argument("screen", metavar="SCREEN_FILE", help="screen file")
+    return parser.parse_args(argv[1:])
+
+
+def main(argv):
+    args = parse_cl(argv)
+    cp = ConfigParser()
+    cp.optionxform = str
+    with open(args.screen) as f:
+        cp.readfp(f)
+    for sec in cp.sections():
+        if not (sec.startswith("Well")):
+            continue
+        for k in cp.options(sec):
+            if not k.startswith("Field_"):
+                continue
+            pattern = cp.get(sec, k)
+            for fn in FilePattern(pattern).filenames():
+                if os.path.exists(fn):
+                    continue
+                sys.stderr.write("ERROR[%s|%s]: missing %r)\n" % (sec, k, fn))
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/check_screen.py
+++ b/scripts/check_screen.py
@@ -30,7 +30,7 @@ def main(argv):
             for fn in FilePattern(pattern).filenames():
                 if os.path.exists(fn):
                     continue
-                sys.stderr.write("ERROR[%s|%s]: missing %r)\n" % (sec, k, fn))
+                sys.stderr.write("ERROR[%s|%s]: missing %r\n" % (sec, k, fn))
 
 
 if __name__ == "__main__":

--- a/test/test_file_pattern.py
+++ b/test/test_file_pattern.py
@@ -13,10 +13,14 @@ class TestRange(unittest.TestCase):
             ("A-e", ValueError),
             ("2-1", ValueError),
             ("B-A", ValueError),
+            ("1-k", ValueError),
+            ("a-9", ValueError),
         ]
         self.good = [
             ("9", ["9"]),
             ("0-2", ["0", "1", "2"]),
+            ("9-11", ["9", "10", "11"]),
+            ("09-11", ["09", "10", "11"]),
             ("1-5:2", ["1", "3", "5"]),
             ("Q", ["Q"]),
             ("A-C", ["A", "B", "C"]),

--- a/test/test_file_pattern.py
+++ b/test/test_file_pattern.py
@@ -1,0 +1,73 @@
+import unittest
+
+import pyidr.file_pattern as fp
+
+
+class TestRange(unittest.TestCase):
+
+    def setUp(self):
+        self.bad = [
+            ("0-2:a", ValueError),
+            ("!-A", ValueError),
+            ("a-E", ValueError),
+            ("A-e", ValueError),
+            ("2-1", ValueError),
+            ("B-A", ValueError),
+        ]
+        self.good = [
+            ("9", ["9"]),
+            ("0-2", ["0", "1", "2"]),
+            ("1-5:2", ["1", "3", "5"]),
+            ("Q", ["Q"]),
+            ("A-C", ["A", "B", "C"]),
+            ("A-E:2", ["A", "C", "E"]),
+            ("q", ["q"]),
+            ("a-c", ["a", "b", "c"]),
+            ("a-e:2", ["a", "c", "e"]),
+        ]
+
+    def test_bad(self):
+        for r, exc in self.bad:
+            self.assertRaises(exc, fp.expand_range, r)
+
+    def test_good(self):
+        for r, exp in self.good:
+            self.assertEqual(fp.expand_range(r), exp)
+
+
+class TestBlock(unittest.TestCase):
+
+    def setUp(self):
+        self.good = [
+            ("1,5-7", ["1", "5", "6", "7"]),
+            ("Red,Green,Blue", ["Red", "Green", "Blue"]),
+        ]
+
+    def runTest(self):
+        for b, exp in self.good:
+            self.assertEqual(fp.expand_block(b), exp)
+
+
+class TestPattern(unittest.TestCase):
+
+    def setUp(self):
+        self.blocks = ["<0-5>", "<r,g,b>", "<10-30:10>"]
+        self.string_pattern = "z%sc%st%s" % tuple(self.blocks)
+        self.pattern = fp.FilePattern(self.string_pattern)
+
+    def runTest(self):
+        self.assertEqual(self.pattern.blocks(), self.blocks)
+
+
+def load_tests(loader, tests, pattern):
+    test_cases = (TestRange, TestBlock)
+    suite = unittest.TestSuite()
+    for tc in test_cases:
+        suite.addTests(loader.loadTestsFromTestCase(tc))
+    return suite
+
+
+if __name__ == "__main__":
+    suite = load_tests(unittest.defaultTestLoader, None, None)
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite)

--- a/test/test_file_pattern.py
+++ b/test/test_file_pattern.py
@@ -55,12 +55,37 @@ class TestBlock(unittest.TestCase):
 class TestPattern(unittest.TestCase):
 
     def setUp(self):
-        self.blocks = ["0-5", "r,g,b", "10-30:10"]
-        self.string_pattern = "z<%s>c<%s>t<%s>" % tuple(self.blocks)
+        self.blocks = ["0-1", "R,G,B", "10-30:10"]
+        self.string_pattern = "z<%s>c<%s>t<%s>.tif" % tuple(self.blocks)
         self.pattern = fp.FilePattern(self.string_pattern)
+        self.expected_fnames = [
+            "z0cRt10.tif",
+            "z0cRt20.tif",
+            "z0cRt30.tif",
+            "z0cGt10.tif",
+            "z0cGt20.tif",
+            "z0cGt30.tif",
+            "z0cBt10.tif",
+            "z0cBt20.tif",
+            "z0cBt30.tif",
+            "z1cRt10.tif",
+            "z1cRt20.tif",
+            "z1cRt30.tif",
+            "z1cGt10.tif",
+            "z1cGt20.tif",
+            "z1cGt30.tif",
+            "z1cBt10.tif",
+            "z1cBt20.tif",
+            "z1cBt30.tif",
+        ]
 
-    def runTest(self):
+    def test_blocks(self):
         self.assertEqual(self.pattern.blocks(), self.blocks)
+
+    def test_filenames(self):
+        self.assertEqual(
+            set(self.pattern.filenames()), set(self.expected_fnames)
+        )
 
 
 def load_tests(loader, tests, pattern):

--- a/test/test_file_pattern.py
+++ b/test/test_file_pattern.py
@@ -55,8 +55,8 @@ class TestBlock(unittest.TestCase):
 class TestPattern(unittest.TestCase):
 
     def setUp(self):
-        self.blocks = ["<0-5>", "<r,g,b>", "<10-30:10>"]
-        self.string_pattern = "z%sc%st%s" % tuple(self.blocks)
+        self.blocks = ["0-5", "r,g,b", "10-30:10"]
+        self.string_pattern = "z<%s>c<%s>t<%s>" % tuple(self.blocks)
         self.pattern = fp.FilePattern(self.string_pattern)
 
     def runTest(self):
@@ -64,7 +64,7 @@ class TestPattern(unittest.TestCase):
 
 
 def load_tests(loader, tests, pattern):
-    test_cases = (TestRange, TestBlock)
+    test_cases = (TestRange, TestBlock, TestPattern)
     suite = unittest.TestSuite()
     for tc in test_cases:
         suite.addTests(loader.loadTestsFromTestCase(tc))


### PR DESCRIPTION
This PR adds limited (no regexes, just `<>` blocks) support for the expansion of [Bio-Formats style patterns](https://www.openmicroscopy.org/site/support/bio-formats5.1/formats/pattern-file.html), together with a script that makes use of the new module to check the existence of all files referenced by a `.screen` file.