### PR TITLE
Add ScreenReader

### DIFF
--- a/pyidr/screenio.py
+++ b/pyidr/screenio.py
@@ -1,13 +1,40 @@
 import string
-from ConfigParser import ConfigParser
+import ConfigParser
+import abc
 
 
-class ScreenWriter(object):
+PLATE = "Plate"
+WELL = "Well %d"
 
-    PLATE = "Plate"
-    WELL = "Well %d"
+
+class ScreenError(Exception):
+    pass
+
+
+class ScreenIO(object):
+
+    @abc.abstractmethod
+    def __init__(self):
+        self.name = None
+        self.screen_name = None
+        self.rows = 0
+        self.columns = 0
+        self.fields = 0
+
+    def index1d(self, i, j):
+        return i * self.columns + j
+
+    def index2d(self, idx):
+        return divmod(idx, self.columns)
+
+    def well_sec(self, idx):
+        return WELL % idx
+
+
+class ScreenWriter(ScreenIO):
 
     def __init__(self, name, rows, columns, fields, screen_name=None):
+        super(ScreenWriter, self).__init__()
         self.name = name
         self.rows = int(rows)
         self.columns = int(columns)
@@ -17,25 +44,19 @@ class ScreenWriter(object):
         self.reset()
 
     def reset(self):
-        self.cp = ConfigParser()
+        self.cp = ConfigParser.ConfigParser()
         self.cp.optionxform = str  # case-sensitive option names
         self.__add_plate_entry()
         self.__well_count = 0
 
     def __add_plate_entry(self):
-        self.cp.add_section(self.PLATE)
-        self.cp.set(self.PLATE, "Name", self.name)
+        self.cp.add_section(PLATE)
+        self.cp.set(PLATE, "Name", self.name)
         if self.screen_name:
-            self.cp.set(self.PLATE, "ScreenName", self.screen_name)
-        self.cp.set(self.PLATE, "Rows", "%d" % self.rows)
-        self.cp.set(self.PLATE, "Columns", "%d" % self.columns)
-        self.cp.set(self.PLATE, "Fields", "%d" % self.fields)
-
-    def index1d(self, i, j):
-        return i * self.columns + j
-
-    def index2d(self, idx):
-        return divmod(idx, self.columns)
+            self.cp.set(PLATE, "ScreenName", self.screen_name)
+        self.cp.set(PLATE, "Rows", "%d" % self.rows)
+        self.cp.set(PLATE, "Columns", "%d" % self.columns)
+        self.cp.set(PLATE, "Fields", "%d" % self.fields)
 
     def coordinates(self, idx):
         i, j = self.index2d(idx)
@@ -61,7 +82,7 @@ class ScreenWriter(object):
         if extra_kv is None:
             extra_kv = {}
         #--
-        sec = self.WELL % idx
+        sec = self.well_sec(idx)
         self.cp.add_section(sec)
         self.cp.set(sec, "Row", "%d" % i)
         self.cp.set(sec, "Column", "%d" % j)
@@ -74,3 +95,78 @@ class ScreenWriter(object):
 
     def write(self, outf):
         self.cp.write(outf)
+
+
+class ScreenReader(ScreenIO):
+
+    def __init__(self, f):
+        super(ScreenReader, self).__init__()
+        self.__f = f
+        self.cp = ConfigParser.ConfigParser()
+        self.cp.optionxform = str
+        self.wells = []
+        self.__read()
+
+    @property
+    def f(self):
+        return self.__f
+
+    def __assert_sec(self, sec):
+        if not self.cp.has_section(sec):
+            raise ScreenError("%r section missing" % (sec,))
+
+    def __checked_get(self, sec, opt, getter_name="get"):
+        getter = getattr(self.cp, getter_name)
+        try:
+            return getter(sec, opt)
+        except ConfigParser.NoOptionError:
+            raise ScreenError("Required %r option missing in %r" % (opt, sec))
+
+    def get(self, sec, opt):
+        return self.__checked_get(sec, opt)
+
+    def getint(self, sec, opt):
+        try:
+            return self.__checked_get(sec, opt, getter_name="getint")
+        except ValueError:
+            raise ScreenError("%r must be an integer" % (opt,))
+
+    def __read(self):
+        self.cp.readfp(self.__f)
+        self.__read_plate()
+        for idx in xrange(self.rows * self.columns):
+            self.__read_well(idx)
+
+    def __read_plate(self):
+        self.__assert_sec(PLATE)
+        self.name = self.get(PLATE, "Name")
+        try:
+            self.screen_name = self.get(PLATE, "ScreenName")
+        except ScreenError:
+            pass
+        self.rows = self.getint(PLATE, "Rows")
+        self.columns = self.getint(PLATE, "Columns")
+        self.fields = self.getint(PLATE, "Fields")
+
+    def __read_well(self, idx):
+        sec = self.well_sec(idx)
+        self.__assert_sec(sec)
+        row = self.getint(sec, "Row")
+        column = self.getint(sec, "Column")
+        exp_r, exp_c = self.index2d(idx)
+        if (row, column) != (exp_r, exp_c):
+            raise ScreenError(
+                "%r: bad (row, column), should be %r" % (sec, (exp_r, exp_c))
+            )
+        w = dict(self.cp.items(sec))
+        fields = []
+        for i in xrange(self.fields):
+            field_key = "Field_%d" % i
+            try:
+                fields.append(self.get(sec, field_key))
+            except ScreenError:
+                pass
+            else:
+                del w[field_key]
+        w['Fields'] = fields
+        self.wells.append(w)

--- a/test/test_screenio.py
+++ b/test/test_screenio.py
@@ -1,31 +1,43 @@
+import os
 import unittest
 from cStringIO import StringIO
-from ConfigParser import ConfigParser, NoOptionError
+import ConfigParser
 
-from pyidr.screenio import ScreenWriter
+from pyidr.screenio import ScreenWriter, ScreenReader, ScreenError
 
 
-class TestScreenWriter(unittest.TestCase):
+class TestScreenIO(unittest.TestCase):
 
     def setUp(self, screen_name=None):
-        fout = StringIO()
         self.name, self.rows, self.columns, self.fields = "Foo", 3, 4, 2
+        self.screen_name = screen_name
         self.size = self.rows * self.columns
+        self.all_field_values = []
+
+    def _field_values(self, idx):
+        values = [
+            "%s_%d_%d.fake" % (self.name, idx, _) for _ in xrange(self.fields)
+        ]
+        self.all_field_values.append(values)
+        return values
+
+
+class TestScreenWriter(TestScreenIO):
+
+    def setUp(self, screen_name=None):
+        super(TestScreenWriter, self).setUp(screen_name=screen_name)
+        fout = StringIO()
         self.all_field_values = []
         self.extra_kv = {"Dimensions": "ZCT"}
         kwargs = {"screen_name": screen_name} if screen_name else {}
         writer = ScreenWriter(
             self.name, self.rows, self.columns, self.fields, **kwargs
         )
-        self.screen_name = screen_name
         for i in xrange(self.size):
-            field_values = ["%s_%02d_%d.fake" % (self.name, i, _)
-                            for _ in xrange(self.fields)]
-            self.all_field_values.append(field_values)
-            writer.add_well(field_values, extra_kv=self.extra_kv)
+            writer.add_well(self._field_values(i), extra_kv=self.extra_kv)
         writer.write(fout)
         fout.seek(0)
-        self.cp = ConfigParser()
+        self.cp = ConfigParser.ConfigParser()
         self.cp.readfp(fout)
 
     def test_sections(self):
@@ -48,7 +60,9 @@ class TestScreenWriter(unittest.TestCase):
         if self.screen_name:
             self.assertEqual(self.cp.get(sec, "ScreenName"), self.screen_name)
         else:
-            self.assertRaises(NoOptionError, self.cp.get, sec, "ScreenName")
+            self.assertRaises(
+                ConfigParser.NoOptionError, self.cp.get, sec, "ScreenName"
+            )
 
     def test_wells(self):
         for i in xrange(self.rows):
@@ -75,8 +89,120 @@ class TestScreenWriterName(TestScreenWriter):
         super(TestScreenWriterName, self).setUp(screen_name="FooScreen")
 
 
+class TestScreenReader(TestScreenIO):
+
+    def setUp(self, screen_name=None):
+        super(TestScreenReader, self).setUp(screen_name=screen_name)
+        self.conf_lines = [
+            "[Plate]",
+            "Name = %s" % self.name,
+            "Rows = %d" % self.rows,
+            "Columns = %d" % self.columns,
+            "Fields = %d" % self.fields,
+        ]
+        if screen_name:
+            self.conf_lines.append("ScreenName = %s" % screen_name)
+        self.conf_lines.append("")
+        for i in xrange(self.rows):
+            for j in xrange(self.columns):
+                idx = (i * self.columns + j)
+                self.conf_lines.extend([
+                    "[Well %d]" % idx,
+                    "Row = %d" % i,
+                    "Column = %d" % j,
+                ])
+                for k, v in enumerate(self._field_values(idx)):
+                    self.conf_lines.append("Field_%d = %s" % (k, v))
+                self.conf_lines.append("")
+        self.f = StringIO()
+        self.f.write(os.linesep.join(self.conf_lines))
+        self.f.seek(0)
+        self.reader = ScreenReader(self.f)
+
+    def test_plate(self):
+        for a in "name", "screen_name", "rows", "columns", "fields":
+            self.assertEqual(getattr(self.reader, a), getattr(self, a))
+
+    def test_wells(self):
+        for idx, w in enumerate(self.reader.wells):
+            self.assertEqual(w['Fields'], self.all_field_values[idx])
+
+
+class TestScreenReaderName(TestScreenReader):
+
+    def setUp(self):
+        super(TestScreenReaderName, self).setUp(screen_name="FooScreen")
+
+
+class TestScreenReaderBad(unittest.TestCase):
+
+    def test_bad_conf(self):
+        self.assertRaises(ConfigParser.Error, ScreenReader, StringIO("foo"))
+
+    def test_missing_sections(self):
+        missing_well = os.linesep.join([
+            "[Plate]",
+            "Name = Foo",
+            "Rows = 1",
+            "Columns = 1",
+            "Fields = 1",
+        ])
+        for bad_content in "", "[Foo]", missing_well:
+            bad_f = StringIO(bad_content)
+            self.assertRaises(ScreenError, ScreenReader, bad_f)
+
+    def test_missing_plate_options(self):
+        conf_lines = [
+            "[Plate]",
+            "Name = Foo",
+            "Rows = 0",
+            "Columns = 0",
+            "Fields = 0",
+        ]
+        for i in xrange(1, len(conf_lines)):
+            copy = conf_lines[:]
+            del copy[i]
+            bad_f = StringIO(os.linesep.join(copy))
+            self.assertRaises(ScreenError, ScreenReader, bad_f)
+
+    def test_bad_plate_options(self):
+        conf_lines = [
+            "[Plate]",
+            "Name = Foo",
+            "Rows = 0",
+            "Columns = 0",
+            "Fields = 0",
+        ]
+        for i in xrange(2, len(conf_lines)):
+            copy = conf_lines[:]
+            copy[i] = copy[i].replace("0", "0.5")
+            bad_f = StringIO(os.linesep.join(copy))
+            self.assertRaises(ScreenError, ScreenReader, bad_f)
+
+    def test_bad_well_idx(self):
+        conf_lines = [
+            "[Plate]",
+            "Name = Foo",
+            "Rows = 1",
+            "Columns = 1",
+            "Fields = 0",
+            "",
+            "[Well 0]",
+            "Row = 0",
+            "Column = 1",
+        ]
+        bad_f = StringIO(os.linesep.join(conf_lines))
+        self.assertRaises(ScreenError, ScreenReader, bad_f)
+
+
 def load_tests(loader, tests, pattern):
-    test_cases = (TestScreenWriter, TestScreenWriterName)
+    test_cases = (
+        TestScreenWriter,
+        TestScreenWriterName,
+        TestScreenReader,
+        TestScreenReaderName,
+        TestScreenReaderBad,
+    )
     suite = unittest.TestSuite()
     for tc in test_cases:
         suite.addTests(loader.loadTestsFromTestCase(tc))


### PR DESCRIPTION
This PR adds a `.screen` reader to the `screenio` module. This can be used (possibly together with `file_pattern`) to check the validity of a `.screen` file.